### PR TITLE
Dodavanje hash funkcije za token

### DIFF
--- a/package/vepar.py
+++ b/package/vepar.py
@@ -333,6 +333,17 @@ class Token(collections.namedtuple('TokenTuple', 'tip sadržaj')):
             return self
         else: return nenavedeno
 
+    def __hash__(self):
+        """Za spremanje tokena u strukture koje koriste hash table (npr. set)."""
+        return hash((self.tip.name, self.sadržaj))
+
+    def __eq__(self, o):
+        """Dva su tokena jednaka ako im se poklapa tip i sadržaj."""
+        return self.tip.name == o.tip.name and self.tip.sadržaj == o.tip.sadržaj
+
+    def __ne__(self, o):
+        return not self.__eq__(o)
+
     def neočekivan(self, info=''):
         """Konstruira sintaksnu grešku: neočekivani tip tokena."""
         if self.tip is KRAJ: poruka = 'Neočekivani kraj ulaza'

--- a/package/vepar.py
+++ b/package/vepar.py
@@ -339,7 +339,7 @@ class Token(collections.namedtuple('TokenTuple', 'tip sadržaj')):
 
     def __eq__(self, o):
         """Dva su tokena jednaka ako im se poklapa tip i sadržaj."""
-        return self.tip.name == o.tip.name and self.tip.sadržaj == o.tip.sadržaj
+        return self.tip.name == o.tip.name and self.sadržaj == o.sadržaj
 
     def __ne__(self, o):
         return not self.__eq__(o)


### PR DESCRIPTION
Dodana je hash funkcija za tip Token kao i operatori __eq__ i __ne__ tako da se omogući spremanje objekata tog tipa u strukture podataka kao što je set, gdje podaci trebaju biti "hashable"